### PR TITLE
Support embedded-hal `1.0.0-alpha.9`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = []
 std = []
 
 [dependencies]
-embedded-hal = "=1.0.0-alpha.8"
+embedded-hal = "=1.0.0-alpha.9"
 
 [dev-dependencies]
 anyhow = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,8 @@
 
 use core::fmt;
 use embedded_hal::{
-    delay::blocking::DelayUs,
-    digital::{
-        blocking::{InputPin, OutputPin},
-        PinState,
-    },
+    delay::DelayUs,
+    digital::{InputPin, OutputPin, PinState},
 };
 
 /// A sensor reading


### PR DESCRIPTION
I started a new project over the holidays and when I went to use `dht-embedded-rs` I wasn't able to (easily) find a version of my dependencies that satisfied all the requirements. My other deps wanted `embedded-hal=1.0.0-alpha.9` but `dht-embedded-rs` wanted `embedded-hal=1.0.0-alpha.8`. The simplest fix seemed to be if I patched `dht-embedded-rs` to support `embedded-hal=1.0.0-alpha.9` and then used the [latest](https://github.com/kj800x/temp-monitor/blob/619c0f318f22f4c76bf0450b2fa3ceeed134e177/rust-probe/Cargo.toml#L18-L32) of all my other dependencies.

It's a pretty small diff to support `alpha.9` with just some namespace changes, so I figured I'd submit this PR.